### PR TITLE
save user params to separate object

### DIFF
--- a/controllers/dietController.js
+++ b/controllers/dietController.js
@@ -9,7 +9,7 @@ const getDiet = async (req, res, next) => {
 
 const getUserDiet = async (req, res, next) => {
   const { _id } = req.user;
-  const user = await User.findByIdAndUpdate(_id, { ...req.body }, { new: true });
+  const user = await User.findByIdAndUpdate(_id, { params: req.body }, { new: true });
 
   if (!user) {
     return next(createNotFoundHttpError());


### PR DESCRIPTION
Об'єкт параметрів користувача має зберігатись в окремому об'єкті params, щоб потім простіше віддавати при доступі до user/current